### PR TITLE
fix: support custom binary path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,9 @@ jobs:
       # Supports custom Artillery binary path.
       # Useful to test against intermediate builds of Artillery.
       - name: Prepare custom binary
-        run: echo "echo \"$1\" >> \"output.txt\"" >> ./custom-binary.sh
+        run: |-
+          echo "echo \"$1\" >> \"output.txt\"" >> ./custom-binary.sh
+          chmod +x ./custom-binary.sh
       - name: Supports custom Artillery binary
         uses: ./
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       # Useful to test against intermediate builds of Artillery.
       - name: Prepare custom binary
         run: |-
-          echo "echo \"$1\" >> \"output.txt\"" >> ./custom-binary.sh
+          echo 'echo "$1" >> ./output.txt' >> ./custom-binary.sh
           chmod +x ./custom-binary.sh
       - name: Supports custom Artillery binary
         uses: ./

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,23 @@ jobs:
         with:
           command: run ./cwd.yml
           working-directory: ./my-dir
+      - name: Cleanup
+        run: rm -rf ./my-dir
+
+      # Supports custom Artillery binary path.
+      # Useful to test against intermediate builds of Artillery.
+      - name: Prepare custom binary
+        run: echo "echo \"$1\" >> \"output.txt\"" >> ./custom-binary.sh
+      - name: Supports custom Artillery binary
+        uses: ./
+        with:
+          command: hello
+        env:
+          ARTILLERY_BINARY_PATH: ./custom-binary.sh
+      - name: Check the output
+        run: '[[ "$(cat ./output.txt)" == "hello" ]] || exit 1'
+      - name: Cleanup
+        run: rm ./custom-binary.sh
 
   release:
     if: github.ref == 'refs/heads/main'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,5 +5,16 @@ if [ -n "${CWD}" ]; then
   cd "${CWD}"
 fi
 
+if [ -n "${ARTILLERY_BINARY_PATH}" ]; then
+  if [ ! -f "${ARTILLERY_BINARY_PATH}" ]; then
+    echo "Failed to locate Artillery binary at custom path: ${ARTILLERY_BINARY_PATH}"
+    exit 1
+  fi
+
+  ARTILLERY_BINARY="${ARTILLERY_BINARY_PATH}"
+else
+  ARTILLERY_BINARY="/home/node/artillery/bin/run"
+fi
+
 # Run the tests.
-/home/node/artillery/bin/run $1
+$ARTILLERY_BINARY $1


### PR DESCRIPTION
Enables support for a custom binary path for Artillery CLI so we could run the action with a custom build of Artillery (e.g. the build from `HEAD`). 
